### PR TITLE
Convert jackson.datatype.guava Optional test cases to jdk8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion> 
+  <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>com.fasterxml.jackson</groupId>
     <artifactId>jackson-parent</artifactId>
@@ -17,7 +17,7 @@ JDK 8 data types.
   <scm>
     <connection>scm:git:git@github.com:FasterXML/jackson-datatype-jdk8.git</connection>
     <developerConnection>scm:git:git@github.com:FasterXML/jackson-datatype-jdk8.git</developerConnection>
-    <url>http://github.com/FasterXML/jackson-datatype-jdk8</url>    
+    <url>http://github.com/FasterXML/jackson-datatype-jdk8</url>
     <tag>HEAD</tag>
   </scm>
   <properties>
@@ -61,6 +61,16 @@ JDK 8 data types.
   </dependencies>
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <version>${version.plugin.surefire}</version>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <exclude>com/fasterxml/jackson/failing/*.java</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
       <plugin>
         <!-- Inherited from oss-base. Generate PackageVersion.java.-->
         <groupId>com.google.code.maven-replacer-plugin</groupId>

--- a/src/test/java/com/fasterxml/jackson/datatype/jdk8/ModuleTestBase.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jdk8/ModuleTestBase.java
@@ -20,6 +20,15 @@ public abstract class ModuleTestBase extends junit.framework.TestCase
         return mapper;
     }
 
+    protected ObjectMapper mapperWithModule(boolean absentsAsNulls)
+    {
+        ObjectMapper mapper = new ObjectMapper();
+        Jdk8Module module = new Jdk8Module();
+        module.configureAbsentsAsNulls(absentsAsNulls);
+        mapper.registerModule(module);
+        return mapper;
+    }
+    
     /*
     /**********************************************************************
     /* Helper methods, setup

--- a/src/test/java/com/fasterxml/jackson/datatype/jdk8/OptionalUnwrappedTest.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jdk8/OptionalUnwrappedTest.java
@@ -1,0 +1,36 @@
+package com.fasterxml.jackson.datatype.jdk8;
+
+import java.util.Optional;
+
+import org.junit.Ignore;
+
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public abstract class OptionalUnwrappedTest extends ModuleTestBase {
+	static class Child {
+		public String name = "Bob";
+	}
+
+	static class Parent {
+		private Child child = new Child();
+
+		@JsonUnwrapped
+		public Child getChild() {
+			return child;
+		}
+	}
+
+	static class OptionalParent {
+		@JsonUnwrapped(prefix = "XX.")
+		public Optional<Child> child = Optional.of(new Child());
+	}
+
+	@Ignore
+	public void failedTestUntypedWithOptionalsNotNulls() throws Exception {
+		final ObjectMapper mapper = mapperWithModule(false);
+		String jsonExp = aposToQuotes("{'XX.name':'Bob'}");
+		String jsonAct = mapper.writeValueAsString(new OptionalParent());
+		assertEquals(jsonExp, jsonAct);
+	}
+}

--- a/src/test/java/com/fasterxml/jackson/datatype/jdk8/TestOptionalBasic.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jdk8/TestOptionalBasic.java
@@ -175,14 +175,6 @@ public class TestOptionalBasic extends ModuleTestBase {
 		assertEquals("{}", value);
 	}
 
-	public void failedTestSerOptNonDefault() throws Exception {
-		OptionalData data = new OptionalData();
-		data.myString = null;
-		String value = mapperWithModule().setSerializationInclusion(
-				JsonInclude.Include.NON_DEFAULT).writeValueAsString(data);
-		assertEquals("{}", value);
-	}
-
 	public void testWithTypingEnabled() throws Exception {
 		final ObjectMapper objectMapper = mapperWithModule();
 		// ENABLE TYPING

--- a/src/test/java/com/fasterxml/jackson/datatype/jdk8/TestOptionalBasic.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jdk8/TestOptionalBasic.java
@@ -1,0 +1,232 @@
+package com.fasterxml.jackson.datatype.jdk8;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.TestConfigureAbsentsAsNulls.OptionalData;
+
+public class TestOptionalBasic extends ModuleTestBase {
+
+	private final ObjectMapper MAPPER = mapperWithModule();
+
+	@JsonAutoDetect(fieldVisibility = Visibility.ANY)
+	public static final class OptionalGenericData<T> {
+		private Optional<T> myData;
+	}
+	
+    @JsonIdentityInfo(generator=ObjectIdGenerators.IntSequenceGenerator.class)
+    public static class Unit
+    {
+        public Optional<Unit> baseUnit;
+        
+		public Unit() {
+		}
+
+		public Unit(final Optional<Unit> u) {
+			baseUnit = u;
+		}
+        
+        public void link(final Unit u) {
+            baseUnit = Optional.of(u);
+        }
+    }
+
+	public void testOptionalTypeResolution() throws Exception {
+		// With 2.6, we need to recognize it as ReferenceType
+		JavaType t = MAPPER.constructType(Optional.class);
+		assertNotNull(t);
+		assertEquals(Optional.class, t.getRawClass());
+		assertTrue(t.isReferenceType());
+	}
+
+	public void testDeserAbsent() throws Exception {
+		Optional<?> value = MAPPER.readValue("null",
+				new TypeReference<Optional<String>>() {
+				});
+		assertFalse(value.isPresent());
+	}
+
+	public void testDeserSimpleString() throws Exception {
+		Optional<?> value = MAPPER.readValue("\"simpleString\"",
+				new TypeReference<Optional<String>>() {
+				});
+		assertTrue(value.isPresent());
+		assertEquals("simpleString", value.get());
+	}
+
+	public void testDeserInsideObject() throws Exception {
+		OptionalData data = MAPPER.readValue("{\"myString\":\"simpleString\"}",
+				OptionalData.class);
+		assertTrue(data.myString.isPresent());
+		assertEquals("simpleString", data.myString.get());
+	}
+
+	public void testDeserComplexObject() throws Exception {
+		TypeReference<Optional<OptionalData>> type = new TypeReference<Optional<OptionalData>>() {
+		};
+		Optional<OptionalData> data = MAPPER.readValue(
+				"{\"myString\":\"simpleString\"}", type);
+		assertTrue(data.isPresent());
+		assertTrue(data.get().myString.isPresent());
+		assertEquals("simpleString", data.get().myString.get());
+	}
+
+	public void testDeserGeneric() throws Exception {
+		TypeReference<Optional<OptionalGenericData<String>>> type = new TypeReference<Optional<OptionalGenericData<String>>>() {
+		};
+		Optional<OptionalGenericData<String>> data = MAPPER.readValue(
+				"{\"myData\":\"simpleString\"}", type);
+		assertTrue(data.isPresent());
+		assertTrue(data.get().myData.isPresent());
+		assertEquals("simpleString", data.get().myData.get());
+	}
+
+	public void testSerAbsent() throws Exception {
+		String value = MAPPER.writeValueAsString(Optional.empty());
+		assertEquals("null", value);
+	}
+
+	public void testSerSimpleString() throws Exception {
+		String value = MAPPER.writeValueAsString(Optional.of("simpleString"));
+		assertEquals("\"simpleString\"", value);
+	}
+
+	public void testSerInsideObject() throws Exception {
+		OptionalData data = new OptionalData();
+		data.myString = Optional.of("simpleString");
+		String value = MAPPER.writeValueAsString(data);
+		assertEquals("{\"myString\":\"simpleString\"}", value);
+	}
+
+	public void testSerComplexObject() throws Exception {
+		OptionalData data = new OptionalData();
+		data.myString = Optional.of("simpleString");
+		String value = MAPPER.writeValueAsString(Optional.of(data));
+		assertEquals("{\"myString\":\"simpleString\"}", value);
+	}
+
+	public void testSerGeneric() throws Exception {
+		OptionalGenericData<String> data = new OptionalGenericData<String>();
+		data.myData = Optional.of("simpleString");
+		String value = MAPPER.writeValueAsString(Optional.of(data));
+		assertEquals("{\"myData\":\"simpleString\"}", value);
+	}
+
+	public void testSerNonNull() throws Exception {
+		OptionalData data = new OptionalData();
+		data.myString = Optional.empty();
+		// NOTE: pass 'true' to ensure "legacy" setting
+		String value = mapperWithModule(true).setSerializationInclusion(
+				JsonInclude.Include.NON_NULL).writeValueAsString(data);
+		assertEquals("{}", value);
+	}
+
+	public void testSerOptDefault() throws Exception {
+		OptionalData data = new OptionalData();
+		data.myString = Optional.empty();
+		String value = mapperWithModule().setSerializationInclusion(
+				JsonInclude.Include.ALWAYS).writeValueAsString(data);
+		assertEquals("{\"myString\":null}", value);
+	}
+
+	public void testSerOptNull() throws Exception {
+		OptionalData data = new OptionalData();
+		data.myString = null;
+		String value = mapperWithModule().setSerializationInclusion(
+				JsonInclude.Include.NON_NULL).writeValueAsString(data);
+		assertEquals("{}", value);
+	}
+
+	public void testSerOptDisableAsNull() throws Exception {
+		final OptionalData data = new OptionalData();
+		data.myString = Optional.empty();
+
+		Jdk8Module mod = new Jdk8Module().configureAbsentsAsNulls(false);
+		ObjectMapper mapper = new ObjectMapper().registerModule(mod)
+				.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+
+		assertEquals("{\"myString\":null}", mapper.writeValueAsString(data));
+
+		// but do exclude with NON_EMPTY
+		mapper = new ObjectMapper().registerModule(mod)
+				.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+		assertEquals("{}", mapper.writeValueAsString(data));
+
+		// and with new (2.6) NON_ABSENT
+		mapper = new ObjectMapper().registerModule(mod)
+				.setSerializationInclusion(JsonInclude.Include.NON_ABSENT);
+		assertEquals("{}", mapper.writeValueAsString(data));
+	}
+
+	public void testSerOptNonEmpty() throws Exception {
+		OptionalData data = new OptionalData();
+		data.myString = null;
+		String value = mapperWithModule().setSerializationInclusion(
+				JsonInclude.Include.NON_EMPTY).writeValueAsString(data);
+		assertEquals("{}", value);
+	}
+
+	public void failedTestSerOptNonDefault() throws Exception {
+		OptionalData data = new OptionalData();
+		data.myString = null;
+		String value = mapperWithModule().setSerializationInclusion(
+				JsonInclude.Include.NON_DEFAULT).writeValueAsString(data);
+		assertEquals("{}", value);
+	}
+
+	public void testWithTypingEnabled() throws Exception {
+		final ObjectMapper objectMapper = mapperWithModule();
+		// ENABLE TYPING
+		objectMapper
+				.enableDefaultTyping(ObjectMapper.DefaultTyping.OBJECT_AND_NON_CONCRETE);
+
+		final OptionalData myData = new OptionalData();
+		myData.myString = Optional.ofNullable("abc");
+
+		final String json = objectMapper.writeValueAsString(myData);
+		final OptionalData deserializedMyData = objectMapper.readValue(json,
+				OptionalData.class);
+		assertEquals(myData.myString, deserializedMyData.myString);
+	}
+
+	public void testObjectId() throws Exception {
+		final Unit input = new Unit();
+		input.link(input);
+		String json = MAPPER.writeValueAsString(input);
+		Unit result = MAPPER.readValue(json, Unit.class);
+		assertNotNull(result);
+		assertNotNull(result.baseUnit);
+		assertTrue(result.baseUnit.isPresent());
+		Unit base = result.baseUnit.get();
+		assertSame(result, base);
+	}
+
+	public void testOptionalCollection() throws Exception {
+
+		TypeReference<List<Optional<String>>> typeReference = new TypeReference<List<Optional<String>>>() {
+		};
+
+		List<Optional<String>> list = new ArrayList<Optional<String>>();
+		list.add(Optional.of("2014-1-22"));
+		list.add(Optional.<String> empty());
+		list.add(Optional.of("2014-1-23"));
+
+		String str = MAPPER.writeValueAsString(list);
+		assertEquals("[\"2014-1-22\",null,\"2014-1-23\"]", str);
+
+		List<Optional<String>> result = MAPPER.readValue(str, typeReference);
+		assertEquals(list.size(), result.size());
+		for (int i = 0; i < list.size(); ++i) {
+			assertEquals("Entry #" + i, list.get(i), result.get(i));
+		}
+	}
+}

--- a/src/test/java/com/fasterxml/jackson/datatype/jdk8/TestOptionalWithPolymorphic.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jdk8/TestOptionalWithPolymorphic.java
@@ -1,0 +1,120 @@
+package com.fasterxml.jackson.datatype.jdk8;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class TestOptionalWithPolymorphic extends ModuleTestBase {
+	static class ContainerA {
+		@JsonProperty
+		private Optional<String> name = Optional.empty();
+		@JsonProperty
+		private Optional<Strategy> strategy = Optional.empty();
+	}
+
+	static class ContainerB {
+		@JsonProperty
+		private Optional<String> name = Optional.empty();
+		@JsonProperty
+		private Strategy strategy = null;
+	}
+
+	@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+	@JsonSubTypes({ @JsonSubTypes.Type(name = "Foo", value = Foo.class),
+			@JsonSubTypes.Type(name = "Bar", value = Bar.class),
+			@JsonSubTypes.Type(name = "Baz", value = Baz.class) })
+	interface Strategy {
+	}
+
+	static class Foo implements Strategy {
+		@JsonProperty
+		private final int foo;
+
+		@JsonCreator
+		Foo(@JsonProperty("foo") int foo) {
+			this.foo = foo;
+		}
+	}
+
+	static class Bar implements Strategy {
+		@JsonProperty
+		private final boolean bar;
+
+		@JsonCreator
+		Bar(@JsonProperty("bar") boolean bar) {
+			this.bar = bar;
+		}
+	}
+
+	static class Baz implements Strategy {
+		@JsonProperty
+		private final String baz;
+
+		@JsonCreator
+		Baz(@JsonProperty("baz") String baz) {
+			this.baz = baz;
+		}
+	}
+
+	/*
+	 * /**********************************************************************
+	 * /* Test methods
+	 * /**********************************************************************
+	 */
+
+	final ObjectMapper MAPPER = mapperWithModule();
+
+	public void testOptionalMapsFoo() throws Exception {
+
+		Map<String, Object> foo = new LinkedHashMap<>();
+		Map<String, Object> loop = new LinkedHashMap<>();
+		loop.put("type", "Foo");
+		loop.put("foo", 42);
+		
+		foo.put("name", "foo strategy");
+		foo.put("strategy", loop);
+		
+		_test(MAPPER, foo);
+	}
+	
+	public void testOptionalMapsBar() throws Exception {
+		
+		Map<String, Object> bar = new LinkedHashMap<>();
+		Map<String, Object> loop = new LinkedHashMap<>();
+		loop.put("type", "Bar");
+		loop.put("bar", true);
+		
+		bar.put("name", "bar strategy");
+		bar.put("strategy", loop);
+		
+		_test(MAPPER, bar);
+	}
+
+	public void testOptionalMapsBaz() throws Exception {
+		Map<String, Object> baz = new LinkedHashMap<>();
+		Map<String, Object> loop = new LinkedHashMap<>();
+		loop.put("type", "Baz");
+		loop.put("baz", "hello world!");
+		
+		baz.put("name", "bar strategy");
+		baz.put("strategy", loop);
+
+		_test(MAPPER, baz);
+	}
+
+	private void _test(ObjectMapper m, Map<String, ?> map) throws Exception {
+		String json = m.writeValueAsString(map);
+
+		ContainerA objA = m.readValue(json, ContainerA.class);
+		assertNotNull(objA);
+
+		ContainerB objB = m.readValue(json, ContainerB.class);
+		assertNotNull(objB);
+	}
+}

--- a/src/test/java/com/fasterxml/jackson/failing/OptionalBasic.java
+++ b/src/test/java/com/fasterxml/jackson/failing/OptionalBasic.java
@@ -1,0 +1,15 @@
+package com.fasterxml.jackson.failing;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.datatype.jdk8.ModuleTestBase;
+import com.fasterxml.jackson.datatype.jdk8.TestConfigureAbsentsAsNulls.OptionalData;
+
+public class OptionalBasic extends ModuleTestBase {
+	public void testSerOptNonDefault() throws Exception {
+		OptionalData data = new OptionalData();
+		data.myString = null;
+		String value = mapperWithModule().setSerializationInclusion(
+				JsonInclude.Include.NON_DEFAULT).writeValueAsString(data);
+		assertEquals("{}", value);
+	}
+}

--- a/src/test/java/com/fasterxml/jackson/failing/OptionalUnwrappedTest.java
+++ b/src/test/java/com/fasterxml/jackson/failing/OptionalUnwrappedTest.java
@@ -1,4 +1,4 @@
-package com.fasterxml.jackson.datatype.jdk8;
+package com.fasterxml.jackson.failing;
 
 import java.util.Optional;
 
@@ -6,8 +6,9 @@ import org.junit.Ignore;
 
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.ModuleTestBase;
 
-public abstract class OptionalUnwrappedTest extends ModuleTestBase {
+public class OptionalUnwrappedTest extends ModuleTestBase {
 	static class Child {
 		public String name = "Bob";
 	}


### PR DESCRIPTION
This pull request is to port the test cases from guava Optional.  

Some test cases are still failing.  Please advise how they should be handled prior to merge.  Currently I simply just ignore those test cases.
1. testSerOptNonDefault
2. testUntypedWithOptionalsNotNulls

I assume these might be known issues ( #10 and #6 ), so I am not going to file issues respectively.
