### PR TITLE
Add failing test

### DIFF
--- a/src/main/java/com/fasterxml/jackson/datatype/jdk8/OptionalSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jdk8/OptionalSerializer.java
@@ -167,7 +167,11 @@ public class OptionalSerializer
 
     @Override
     public boolean isEmpty(SerializerProvider provider, Optional<?> value) {
-        return (value == null) || !value.isPresent();
+        return (value == null) || !value.isPresent() || isValueEmpty(value.get());
+    }
+
+    protected boolean isValueEmpty(Object value) {
+        return (value instanceof String) && ((String)value).isEmpty();
     }
 
     @Override

--- a/src/test/java/com/fasterxml/jackson/datatype/jdk8/OptionalTest.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jdk8/OptionalTest.java
@@ -210,6 +210,13 @@ public class OptionalTest extends ModuleTestBase
                 mapper.writeValueAsString(new OptionalLongBean()));
     }
 
+    public void testExcludeIfOptionalStringIsBlank() throws Exception {
+        ObjectMapper mapper = mapperWithModule()
+                .setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+        assertEquals(aposToQuotes("{}"),
+                mapper.writeValueAsString(new OptionalStringBean("")));
+    }
+
     /*
     /**********************************************************
     /* Helper methods


### PR DESCRIPTION
Adds a failing test that shows blank optional strings are still serialized even when `JsonInclude.NON_EMPTY` is set.