### PR TITLE
Fix OptionalSerializer.isEmpty() from an incorrect class cast exception.

### DIFF
--- a/src/main/java/com/fasterxml/jackson/datatype/jdk8/OptionalSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jdk8/OptionalSerializer.java
@@ -215,7 +215,7 @@ public class OptionalSerializer
         JsonSerializer<Object> ser = _valueSerializer;
         if (ser == null) {
             try {
-                ser = _findCachedSerializer(provider, value.getClass());
+                ser = _findCachedSerializer(provider, contents.getClass());
             } catch (JsonMappingException e) { // nasty but necessary
                 throw new RuntimeJsonMappingException(e);
             }

--- a/src/test/java/com/fasterxml/jackson/datatype/jdk8/OptionalnclusionTest.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jdk8/OptionalnclusionTest.java
@@ -29,6 +29,15 @@ public class OptionalnclusionTest extends ModuleTestBase
         }
     }
 
+    public static final class OptionalGenericData<T> {
+        public Optional<T> myData;
+        public static <T> OptionalGenericData<T> construct(T data) {
+            OptionalGenericData<T> ret = new OptionalGenericData<T>();
+            ret.myData = Optional.of(data);
+            return ret;
+        }
+    }
+
     private final ObjectMapper MAPPER = mapperWithModule();
 
     public void testSerOptNonEmpty() throws Exception
@@ -57,5 +66,41 @@ public class OptionalnclusionTest extends ModuleTestBase
         assertEquals("{}", json);
         json = MAPPER.writeValueAsString(new OptionalNonEmptyStringBean(""));
         assertEquals("{}", json);
+    }
+
+    public void testSerPropInclusionAlways() throws Exception
+    {
+        JsonInclude.Value incl =
+                JsonInclude.Value.construct(JsonInclude.Include.NON_ABSENT, JsonInclude.Include.ALWAYS);
+        ObjectMapper mapper = mapperWithModule().setPropertyInclusion(incl);
+        assertEquals("{\"myData\":true}",
+                mapper.writeValueAsString(OptionalGenericData.construct(Boolean.TRUE)));
+    }
+
+    public void testSerPropInclusionNonNull() throws Exception
+    {
+        JsonInclude.Value incl =
+                JsonInclude.Value.construct(JsonInclude.Include.NON_ABSENT, JsonInclude.Include.NON_NULL);
+        ObjectMapper mapper = mapperWithModule().setPropertyInclusion(incl);
+        assertEquals("{\"myData\":true}",
+                mapper.writeValueAsString(OptionalGenericData.construct(Boolean.TRUE)));
+    }
+
+    public void testSerPropInclusionNonAbsent() throws Exception
+    {
+        JsonInclude.Value incl =
+                JsonInclude.Value.construct(JsonInclude.Include.NON_ABSENT, JsonInclude.Include.NON_ABSENT);
+        ObjectMapper mapper = mapperWithModule().setPropertyInclusion(incl);
+        assertEquals("{\"myData\":true}",
+                mapper.writeValueAsString(OptionalGenericData.construct(Boolean.TRUE)));
+    }
+
+    public void testSerPropInclusionNonEmpty() throws Exception
+    {
+        JsonInclude.Value incl =
+                JsonInclude.Value.construct(JsonInclude.Include.NON_ABSENT, JsonInclude.Include.NON_EMPTY);
+        ObjectMapper mapper = mapperWithModule().setPropertyInclusion(incl);
+        assertEquals("{\"myData\":true}",
+                mapper.writeValueAsString(OptionalGenericData.construct(Boolean.TRUE)));
     }
 }


### PR DESCRIPTION
Similar to FasterXML/jackson-datatypes-collections#4, JDK8's OptionalSerializer may accidentally cause a class cast exception by using the Optional<T> class instead of the T class.