### PR TITLE
Fix for contextualization not being applied to cached serializers

### DIFF
--- a/src/main/java/com/fasterxml/jackson/datatype/jdk8/OptionalSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jdk8/OptionalSerializer.java
@@ -315,6 +315,7 @@ public class OptionalSerializer
             }
             _dynamicSerializers = _dynamicSerializers.newWith(type, ser);
         }
+        ser = (JsonSerializer<Object>)provider.handlePrimaryContextualization(ser, _property);
         return ser;
     }
 


### PR DESCRIPTION
In regards to https://github.com/FasterXML/jackson-modules-java8/issues/17